### PR TITLE
create an esm build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "ngryman/tree-crawl",
   "main": "dist/tree-crawl.js",
   "browser": "dist/tree-crawl.js",
-  "module": "index.js",
+  "module": "dist/tree-crawl.ems.js",
   "jsnext:main": "index.js",
   "types": "index.d.ts",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-crawl",
-  "version": "1.0.5",
+  "version": "1.1.0-0",
   "description": "Agnostic tree traversal library.",
   "author": "Nicolas Gryman <ngryman@gmail.com> (http://ngryman.sh/)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-crawl",
-  "version": "1.1.0-0",
+  "version": "1.1.0",
   "description": "Agnostic tree traversal library.",
   "author": "Nicolas Gryman <ngryman@gmail.com> (http://ngryman.sh/)",
   "license": "MIT",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,10 +6,13 @@ import cleanup from 'rollup-plugin-cleanup'
 export default {
   name: 'crawl',
   input: 'index.js',
-  output: {
+  output: [{
     format: 'umd',
     file: 'dist/tree-crawl.js'
-  },
+  }, {
+    format: 'es',
+    file: 'dist/tree-crawl.esm.js'
+  }],
   plugins: [
     resolve({
       jsnext: true,


### PR DESCRIPTION
Fixes #64.

This PR adds an ESM build.

@jdittrich Could try this and let me know if this works for you?

You can install the published canary version by this PR:
```sh
npm i tree-crawl@canary
// or
yarn add tree-crawl@canary.
```

