### PR TITLE
Fix typo in package.json so ESM import works

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "ngryman/tree-crawl",
   "main": "dist/tree-crawl.js",
   "browser": "dist/tree-crawl.js",
-  "module": "dist/tree-crawl.ems.js",
+  "module": "dist/tree-crawl.esm.js",
   "jsnext:main": "index.js",
   "types": "index.d.ts",
   "engines": {


### PR DESCRIPTION
Hello, current version is broken. This PR would fix it.

Want me to update the version(minor) as well?
<img width="918" alt="Screenshot 2022-06-15 at 03 30 37" src="https://user-images.githubusercontent.com/37350/173716097-f22ce878-4f3b-49a4-968d-6020c8f1c996.png">

