### PR TITLE
Fix paths in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "author": "Nicolas Gryman <ngryman@gmail.com> (http://ngryman.sh/)",
   "license": "MIT",
   "repository": "ngryman/tree-crawl",
-  "main": "dist/tree-crawl.js",
-  "browser": "dist/tree-crawl.js",
-  "module": "dist/tree-crawl.esm.js",
+  "main": "index.js",
+  "browser": "index.js",
+  "module": "index.js",
   "jsnext:main": "index.js",
   "types": "index.d.ts",
   "engines": {


### PR DESCRIPTION
Hey @ngryman 

The published package right now is broken since the package.json references a dist folder which isn't present in published sources. See attached images

<img width="1011" alt="Screenshot 2022-08-27 at 00 28 51" src="https://user-images.githubusercontent.com/37350/186973530-7a280921-2693-47a1-aeda-6ba727fe7f50.png">
<img width="304" alt="Screenshot 2022-08-27 at 00 29 04" src="https://user-images.githubusercontent.com/37350/186973569-9d50d3bb-ff1d-4344-9685-39e919b49449.png">

